### PR TITLE
Auto graph list

### DIFF
--- a/Assets/GraphVisualizer/Clients/GraphVisualizerClient.cs
+++ b/Assets/GraphVisualizer/Clients/GraphVisualizerClient.cs
@@ -8,7 +8,7 @@ using UnityEngine.Playables;
 public class GraphVisualizerClient
 {
     private static GraphVisualizerClient s_Instance;
-    private Dictionary<PlayableGraph, string> m_Graphs = new Dictionary<PlayableGraph, string>();
+    private List<PlayableGraph> m_Graphs = new List<PlayableGraph>();
 
     public static GraphVisualizerClient instance
     {
@@ -19,26 +19,29 @@ public class GraphVisualizerClient
             return s_Instance;
         }
     }
+
     ~GraphVisualizerClient()
     {
         m_Graphs.Clear();
     }
-    public static void Show(PlayableGraph graph, string name)
+
+    public static void Show(PlayableGraph graph)
     {
-        if (!instance.m_Graphs.ContainsKey(graph))
+        if (!instance.m_Graphs.Contains(graph))
         {
-            instance.m_Graphs.Add(graph, name);
+            instance.m_Graphs.Add(graph);
         }
     }
+
     public static void Hide(PlayableGraph graph)
     {
-        if (instance.m_Graphs.ContainsKey(graph))
+        if (instance.m_Graphs.Contains(graph))
         {
             instance.m_Graphs.Remove(graph);
         }
     }
 
-    public static IEnumerable<KeyValuePair<PlayableGraph, string>> GetGraphs()
+    public static IEnumerable<PlayableGraph> GetGraphs()
     {
         return instance.m_Graphs;
     }

--- a/Assets/GraphVisualizer/Editor/PlayableGraphVisualizerWindow.cs
+++ b/Assets/GraphVisualizer/Editor/PlayableGraphVisualizerWindow.cs
@@ -8,34 +8,28 @@ using UnityEditor.Animations;
 
 public class PlayableGraphVisualizerWindow : EditorWindow, IHasCustomMenu
 {
-    private struct PlayableGraphInfo
-    {
-        public PlayableGraph graph;
-        public string name;
-    }
-
     private IGraphRenderer m_Renderer;
     private IGraphLayout m_Layout;
 
-    private PlayableGraphInfo m_CurrentGraphInfo;
+    private List<PlayableGraph> m_Graphs;
+    private PlayableGraph m_CurrentGraph;
     private GraphSettings m_GraphSettings;
-    private bool m_AutoScanScene = true;
 
-    #region Configuration
+#region Configuration
 
     private static readonly float s_ToolbarHeight = 17f;
     private static readonly float s_DefaultMaximumNormalizedNodeSize = 0.8f;
     private static readonly float s_DefaultMaximumNodeSizeInPixels = 100.0f;
     private static readonly float s_DefaultAspectRatio = 1.5f;
 
-    #endregion
+#endregion
+
     private PlayableGraphVisualizerWindow()
     {
         m_GraphSettings.maximumNormalizedNodeSize = s_DefaultMaximumNormalizedNodeSize;
         m_GraphSettings.maximumNodeSizeInPixels = s_DefaultMaximumNodeSizeInPixels;
         m_GraphSettings.aspectRatio = s_DefaultAspectRatio;
         m_GraphSettings.showLegend = true;
-        m_AutoScanScene = true;
     }
 
     [MenuItem("Window/PlayableGraph Visualizer")]
@@ -44,27 +38,28 @@ public class PlayableGraphVisualizerWindow : EditorWindow, IHasCustomMenu
         GetWindow<PlayableGraphVisualizerWindow>("PlayableGraph Visualizer");
     }
 
-    private PlayableGraphInfo GetSelectedGraphInToolBar(IList<PlayableGraphInfo> graphs, PlayableGraphInfo currentGraph)
+    private PlayableGraph GetSelectedGraphInToolBar(List<PlayableGraph> graphs, PlayableGraph currentGraph)
     {
         EditorGUILayout.BeginHorizontal(EditorStyles.toolbar, GUILayout.Width(position.width));
 
-        List<string> options = new List<string>(graphs.Count);// = graphs.Select(d => d.ToString()).ToArray();
-        foreach (var g in graphs)
+        List<string> options = new List<string>(graphs.Count);
+        foreach (var graph in graphs)
         {
-            options.Add(g.name);
+            string name = graph.GetEditorName();
+            options.Add(name.Length != 0 ? name : "[Unnamed]");
         }
 
         int currentSelection = graphs.IndexOf(currentGraph);
         int newSelection = EditorGUILayout.Popup(currentSelection != -1 ? currentSelection : 0, options.ToArray(), GUILayout.Width(200));
 
-        PlayableGraphInfo selectedDirector = new PlayableGraphInfo();
+        PlayableGraph selectedGraph = new PlayableGraph();
         if (newSelection != -1)
-            selectedDirector = graphs[newSelection];
+            selectedGraph = graphs[newSelection];
 
         GUILayout.FlexibleSpace();
         EditorGUILayout.EndHorizontal();
 
-        return selectedDirector;
+        return selectedGraph;
     }
 
     private static void ShowMessage(string msg)
@@ -98,78 +93,52 @@ public class PlayableGraphVisualizerWindow : EditorWindow, IHasCustomMenu
             Repaint();
     }
 
+    void OnEnable()
+    {
+        m_Graphs = new List<PlayableGraph>(UnityEditor.Playables.Utility.GetAllGraphs());
+
+        UnityEditor.Playables.Utility.graphCreated += OnGraphCreated;
+        UnityEditor.Playables.Utility.destroyingGraph += OnDestroyingGraph;
+    }
+
+    void OnGraphCreated(PlayableGraph graph)
+    {
+        if (!m_Graphs.Contains(graph))
+            m_Graphs.Add(graph);
+    }
+
+    void OnDestroyingGraph(PlayableGraph graph)
+    {
+        m_Graphs.Remove(graph);
+    }
+
+    void OnDisable()
+    {
+        UnityEditor.Playables.Utility.graphCreated -= OnGraphCreated;
+        UnityEditor.Playables.Utility.destroyingGraph -= OnDestroyingGraph;
+    }
+
     void OnGUI()
     {
-        // Create a list of all the playable graphs extracted.
-        IList<PlayableGraphInfo> graphInfos = new List<PlayableGraphInfo>();
-
-        PlayableGraphInfo info;
-
-        // If we requested, we extract automatically the PlayableGraphs from all the components
-        // that are in the current scene.
-        if (m_AutoScanScene)
-        {
-            // This code could be generalized, maybe if we added a IHasPlayableGraph Interface.
-            IList<PlayableDirector> directors = FindObjectsOfType<PlayableDirector>();
-            if (directors != null)
-            {
-                foreach (var director in directors)
-                {
-                    if (director.playableGraph.IsValid())
-                    {
-                        info.name = director.name;
-                        info.graph = director.playableGraph;
-                        graphInfos.Add(info);
-                    }
-                }
-            }
-
-            IList<Animator> animators = FindObjectsOfType<Animator>();
-            if (animators != null)
-            {
-                foreach (var animator in animators)
-                {
-                    if (animator.playableGraph.IsValid())
-                    {
-                        info.name = animator.name;
-                        info.graph = animator.playableGraph;
-                        graphInfos.Add(info);
-                    }
-                }
-            }
-        }
-
-        if (GraphVisualizerClient.GetGraphs() != null)
-        {
-            foreach (var clientGraph in GraphVisualizerClient.GetGraphs())
-            {
-                if (clientGraph.Key.IsValid())
-                {
-                    info.name = clientGraph.Value;
-                    info.graph = clientGraph.Key;
-                    graphInfos.Add(info);
-                }
-            }
-        }
-
         // Early out if there is no graphs.
-        if (graphInfos.Count == 0)
+        var selectedGraphs = GetGraphList();
+        if (selectedGraphs.Count == 0)
         {
             ShowMessage("No PlayableGraph in the scene");
             return;
         }
 
         GUILayout.BeginVertical();
-        m_CurrentGraphInfo = GetSelectedGraphInToolBar(graphInfos, m_CurrentGraphInfo);
+        m_CurrentGraph = GetSelectedGraphInToolBar(selectedGraphs, m_CurrentGraph);
         GUILayout.EndVertical();
 
-        if (!m_CurrentGraphInfo.graph.IsValid())
+        if (!m_CurrentGraph.IsValid())
         {
             ShowMessage("Selected PlayableGraph is invalid");
             return;
         }
 
-        var graph = new PlayableGraphVisualizer(m_CurrentGraphInfo.graph);
+        var graph = new PlayableGraphVisualizer(m_CurrentGraph);
         graph.Refresh();
 
         if (graph.IsEmpty())
@@ -191,20 +160,31 @@ public class PlayableGraphVisualizerWindow : EditorWindow, IHasCustomMenu
         m_Renderer.Draw(m_Layout, graphRect, m_GraphSettings);
     }
 
+    private List<PlayableGraph> GetGraphList()
+    {
+        var selectedGraphs = new List<PlayableGraph>();
+        foreach (var clientGraph in GraphVisualizerClient.GetGraphs())
+        {
+            if (clientGraph.IsValid())
+                selectedGraphs.Add(clientGraph);
+        }
+
+        if (selectedGraphs.Count == 0)
+            selectedGraphs = m_Graphs.ToList();
+
+        return selectedGraphs;
+    }
+
 #region Custom_Menu
 
     public virtual void AddItemsToMenu(GenericMenu menu)
     {
         menu.AddItem(new GUIContent("Legend"), m_GraphSettings.showLegend, ToggleLegend);
-        menu.AddItem(new GUIContent("Auto Scan Scene"), m_AutoScanScene, ToggleAutoScanScene);
     }
+
     void ToggleLegend()
     {
         m_GraphSettings.showLegend = !m_GraphSettings.showLegend;
-    }
-    void ToggleAutoScanScene()
-    {
-        m_AutoScanScene = !m_AutoScanScene;
     }
 
 #endregion

--- a/Assets/GraphVisualizer/Editor/PlayableGraphVisualizerWindow.cs
+++ b/Assets/GraphVisualizer/Editor/PlayableGraphVisualizerWindow.cs
@@ -41,7 +41,7 @@ public class PlayableGraphVisualizerWindow : EditorWindow, IHasCustomMenu
     [MenuItem("Window/PlayableGraph Visualizer")]
     public static void ShowWindow()
     {
-        GetWindow<PlayableGraphVisualizerWindow>("Playable Graph Visualizer");
+        GetWindow<PlayableGraphVisualizerWindow>("PlayableGraph Visualizer");
     }
 
     private PlayableGraphInfo GetSelectedGraphInToolBar(IList<PlayableGraphInfo> graphs, PlayableGraphInfo currentGraph)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
-# PlayableGraph Visualizer #
-## Introduction ##
-The PlayableGraph Visualizer window can be used to display any *PlayableGraph*.
+# PlayableGraph Visualizer
+
+## Introduction
+
+The PlayableGraph Visualizer window can be used to display any `PlayableGraph`.
 The tool can be used in both Play and Edit mode and will always reflect the current state of the graph.
 Playable Handles in the graph are represented by colored nodes, varying according to their type. Wire color intensity indicates the local weight of the blending.
-## Setup ##
+
+## Setup
+
 - Download the release that matches your current Unity version, or the latest if there your Unity version is more recent than the latest release.
 - Copy the content of this repos Asset folder into a the Asset folder of an Unity Project.  You will need to do this for every project.
-## Window ##
+
+## Window
+
 - You can open the Timeline Visualizer in **Window > PlayableGraph Visualizer**.
-## Usage ##
-- Open any scene that contains at least one *PlayableGraph*.
-- Register your *PlayableGraph* with the method GraphVisualizerClient.Show(PlayableGraph, string).
-- Select the *PlayableGraph* to display in the top-left combo box.
+
+## Usage
+
+- Open any scene that contains at least one `PlayableGraph`.
+- Register your `PlayableGraph` with the method `GraphVisualizerClient.Show(PlayableGraph, string)`.
+- Select the `PlayableGraph` to display in the top-left list.
 - Click on a Node to display more information about the associated Playable Handle.
-## Notes ##
-- This tool was previously named Timeline Visualizer, but was renamed as we are refactoring it to support *PlayableGraph* stored in different types of component.
-- If your *PlayableGraph* is only available in Play mode, you will not be able to see it in Edit mode.
+
+## Notes
+
+- This tool was previously named Timeline Visualizer, but was renamed as we are refactoring it to support `PlayableGraph` stored in different types of component.
+- If your `PlayableGraph` is only available in Play mode, you will not be able to see it in Edit mode.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Playable Handles in the graph are represented by colored nodes, varying accordin
 ## Usage
 
 - Open any scene that contains at least one `PlayableGraph`.
-- Register your `PlayableGraph` with the method `GraphVisualizerClient.Show(PlayableGraph, string)`.
+- By default, all the `PlayableGraph`s of your scene will be listed in the editor's top-left list.
+	- You can show just your `PlayableGraph` using `GraphVisualizerClient.Show(PlayableGraph)`.
 - Select the `PlayableGraph` to display in the top-left list.
 - Click on a Node to display more information about the associated Playable Handle.
 


### PR DESCRIPTION
Now, by default, all the created graphs are listed in the window top-left list, but it is still possible to show one (or more) specific graphs using `GraphVisualizerClient.Show()`.

The graphs created by the engine (through the Animator or the Director component for instance) are prefixed by their GameObject name, making it easier to understand from where the graphs come.