### PR TITLE
Fix compil error with Unity 2018.1 or less

### DIFF
--- a/Editor/PlayableNodes/PlayableOutputNode.cs
+++ b/Editor/PlayableNodes/PlayableOutputNode.cs
@@ -45,7 +45,11 @@ namespace GraphVisualizer
             {
                 sb.AppendLine(InfoString("IsValid", po.IsOutputValid()));
                 sb.AppendLine(InfoString("Weight", po.GetWeight()));
+#if UNITY_2018_2_OR_NEWER
                 sb.AppendLine(InfoString("SourceOutputPort", po.GetSourceOutputPort()));
+#else
+                sb.AppendLine(InfoString("SourceInputPort", po.GetSourceInputPort()));
+#endif
             }
 
             return sb.ToString();


### PR DESCRIPTION
The function `PlayableOutput.SetSourceInputPort` has been renamed to `PlayableOutput.SetSourceOutputPort` in Unity 2018.2.0a6. This PR brings compatibility for Unity 2018.1 or before.

Fix #12  