### PR TITLE
Add the name of the playable output in the inspector

### DIFF
--- a/Editor/PlayableNodes/PlayableOutputNode.cs
+++ b/Editor/PlayableNodes/PlayableOutputNode.cs
@@ -43,6 +43,9 @@ namespace GraphVisualizer
             var po = (PlayableOutput) content;
             if (po.IsOutputValid())
             {
+#if UNITY_2019_1_OR_NEWER
+                sb.AppendLine(InfoString("Name", po.GetEditorName()));
+#endif
                 sb.AppendLine(InfoString("IsValid", po.IsOutputValid()));
                 sb.AppendLine(InfoString("Weight", po.GetWeight()));
 #if UNITY_2018_2_OR_NEWER


### PR DESCRIPTION
In 2019.1, PlayableOutput will have a new method allowing to get the PlayableOutput name. Like for the PlayableGraph it's called GetEditorName, and it will also be editor only, which is fine in this case.