### PR TITLE
Add support for naming graphs

### DIFF
--- a/Editor/PlayableGraphVisualizerWindow.cs
+++ b/Editor/PlayableGraphVisualizerWindow.cs
@@ -46,7 +46,11 @@ namespace GraphVisualizer
             List<string> options = new List<string>(graphs.Count);
             foreach (var graph in graphs)
             {
-                string name = graph.GetEditorName();
+                string name = GraphVisualizerClient.GetName(graph);
+                if (name == null)
+                {
+                    name = graph.GetEditorName();
+                }
                 options.Add(name.Length != 0 ? name : "[Unnamed]");
             }
 

--- a/Editor/PlayableGraphVisualizerWindow.cs
+++ b/Editor/PlayableGraphVisualizerWindow.cs
@@ -54,6 +54,8 @@ namespace GraphVisualizer
                 options.Add(name.Length != 0 ? name : "[Unnamed]");
             }
 
+            options.Sort();
+
             int currentSelection = graphs.IndexOf(currentGraph);
             int newSelection = EditorGUILayout.Popup(currentSelection != -1 ? currentSelection : 0, options.ToArray(), GUILayout.Width(200));
 

--- a/Runtime/GraphVisualizerClient.cs
+++ b/Runtime/GraphVisualizerClient.cs
@@ -7,6 +7,7 @@ public class GraphVisualizerClient
 {
     private static GraphVisualizerClient s_Instance;
     private List<PlayableGraph> m_Graphs = new List<PlayableGraph>();
+    private Dictionary<PlayableGraph, string> m_GraphNames = new Dictionary<PlayableGraph, string>();
 
     public static GraphVisualizerClient instance
     {
@@ -25,18 +26,26 @@ public class GraphVisualizerClient
 
     public static void Show(PlayableGraph graph)
     {
+#if UNITY_EDITOR
+        Show(graph, graph.GetEditorName());
+#else
+        Show(graph, null);
+#endif
+    }
+
+    public static void Show(PlayableGraph graph, string name)
+    {
         if (!instance.m_Graphs.Contains(graph))
         {
             instance.m_Graphs.Add(graph);
         }
+        instance.m_GraphNames[graph] = name;
     }
 
     public static void Hide(PlayableGraph graph)
     {
-        if (instance.m_Graphs.Contains(graph))
-        {
-            instance.m_Graphs.Remove(graph);
-        }
+        instance.m_Graphs.Remove(graph);
+        instance.m_GraphNames.Remove(graph);
     }
 
     public static void ClearGraphs()
@@ -47,5 +56,14 @@ public class GraphVisualizerClient
     public static IEnumerable<PlayableGraph> GetGraphs()
     {
         return instance.m_Graphs;
+    }
+
+    public static string GetName(PlayableGraph graph)
+    {
+        if (instance.m_GraphNames.TryGetValue(graph, out var name))
+        {
+            return name;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This PR adds an overload to GraphVisualizerClient.Show that takes a name: 

`public static void Show(PlayableGraph graph, string name)`

This allows users to pick a name for their graph that's shown when picking the graph in the visualizer window. It also allows updating the graph name at runtime.

We need this for our [AnimationPlayer](https://github.com/Baste-RainGames/AnimationPlayer) library. When debugging it, it's useful to look at the graph it produces in the graph visualizer. Enabling renaming of the visualizer makes that process easier, as we can change the name shown in the dropdown in a less intrusive way.

As an added bonus, I made the list of names sort, so it's easier to look through.