### PR TITLE
Added support for Timeline

### DIFF
--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -1,5 +1,7 @@
 editors:
   - version: 2019.1
+  - version: 2019.3
+  - version: trunk
 platforms:
   - name: win
     type: Unity::VM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2019-06-10
+
+### Added
+
+- Visualizer now supports pass through nodes. Timeline graphs will now show only relevant Playables for a given PlayableOutput.
+
+
+
 ## [0.2.1] - 2019-02-07
 
 ### Added

--- a/Editor/Graph/Graph.cs
+++ b/Editor/Graph/Graph.cs
@@ -24,6 +24,9 @@ namespace GraphVisualizer
 
         // Derived class should implement how to populate this graph (usually by calling AddNodeHierarchy()).
         protected abstract void Populate();
+        
+        // Derived class can implement this to filter the graph during AddNodeHierarchy
+        protected virtual bool ShouldAddChild(Node parent, Node child) { return true; }
 
         public void AddNodeHierarchy(Node root)
         {
@@ -35,6 +38,9 @@ namespace GraphVisualizer
 
             foreach (Node child in children)
             {
+                if (!ShouldAddChild(root, child))
+                    continue;
+
                 root.AddChild(child);
                 AddNodeHierarchy(child);
             }

--- a/Editor/PlayableGraphVisualizer.cs
+++ b/Editor/PlayableGraphVisualizer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using UnityEngine.Animations;
 using UnityEngine.Playables;
 
@@ -59,6 +60,45 @@ namespace GraphVisualizer
             return inputs;
         }
 
+        protected override bool ShouldAddChild(Node parent, Node child)
+        {
+            var grandParent = parent.parent;
+            if (child is PlayableNode && parent is PlayableNode && grandParent != null)
+            {
+                Playable p = (Playable) parent.content;
+                if (p.GetTraversalMode() == PlayableTraversalMode.Passthrough)
+                {
+                    int index = -1;
+                    int childIndex = FindInputIndex(p, (Playable) child.content);
+                    if (grandParent is PlayableOutputNode)
+                    {
+                        var output = (PlayableOutput) grandParent.content;
+                        index = Math.Max(0,output.GetSourceOutputPort());
+                    }
+                    else if (grandParent is PlayableNode)
+                    {
+                        index = FindInputIndex((Playable) grandParent.content, p);
+                    }
+
+                    if (index != -1 && childIndex != -1)
+                        return index == childIndex;
+                }
+            }
+            return base.ShouldAddChild(parent, child);
+        }
+
+        private int FindInputIndex(Playable output, Playable input)
+        {
+            int inputCount = output.GetInputCount();
+            for (int i = 0; i < inputCount; i++)
+            {
+                if (output.GetInput(i).Equals(input))
+                    return i;
+            }
+
+            return -1;
+        }
+        
         private List<Node> GetInputsFromPlayableOutputNode(PlayableOutput h)
         {
             var inputs = new List<Node>();


### PR DESCRIPTION
Supports the pass through traversal mode. This makes timeline graph appear as one subgraph per output, instead of showing the entire graph for each output. 